### PR TITLE
Some small tweaks, mainly for the Easter egg

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,11 +116,12 @@ textarea { width:500px }
 
 <script>
 var current_word_count = 0;
-var words_for_rewrd = 100;
+var words_for_reward = 100;
 var kittens_earned = 0;
 var kittens_shown = 0;
 var warning_shown = false;
-var license_list="1,2,3,4,5,6,7"; 
+var license_list = {};
+var licenses_ok = [1,2,3,4,5,6,7]; 
 /*
 4 - Attribution License (http://creativecommons.org/licenses/by/2.0/)
 6 - Attribution-NoDerivs License (http://creativecommons.org/licenses/by-nd/2.0/)
@@ -139,6 +140,27 @@ var next_kitten = {
   page_url: '',
   alt: ''
 };
+
+//Get license info
+var license_url = "http://api.flickr.com/services/rest/?format=json&method=flickr.photos.licenses.getInfo&api_key=5dfc80756edad8d0566cf40f0909324e&jsoncallback=?";
+var custom_shorts = {"No known copyright restrictions": "Flickr Commons"};
+$.getJSON(license_url, function(data) {
+  if (data.stat == "ok") {
+    $.each(data.licenses.license,function(idx,el) {
+      licdata = {"name": el.name,"url": el.url};
+      //Assign short
+      if(shortcc = licdata.url.match(/creativecommons\.org\/licenses\/([^\/]+)\//)) {
+        licdata["shortname"] = 'CC-' + shortcc[1].toUpperCase();
+      } else if(custshort = custom_shorts[licdata.name]) {
+        licdata["shortname"] = custshort;
+      } else {
+        licdata["shortname"] = licdata.name;
+      }
+
+      license_list[el.id] = licdata;
+    });
+  }
+});
 
 function word_count(text, wc) {
   if (typeof localStorage != "undefined") localStorage.text = text;
@@ -189,16 +211,24 @@ function fetch_next_kitten() {
     search = "kitten,cute";
   }
 
-  var license_list 
-  var flickr_url = "http://api.flickr.com/services/rest/?format=json&sort=interestingness-desc&method=flickr.photos.search&license=" + license_list + "&extras=owner_name&tags=" + escape(search) + "&tag_mode=all&api_key=5dfc80756edad8d0566cf40f0909324e&jsoncallback=?";
+  license_csv = licenses_ok.join(',');
+  var flickr_url = "http://api.flickr.com/services/rest/?format=json&sort=interestingness-desc&method=flickr.photos.search&license=" + license_csv + "&extras=owner_name,license&tags=" + escape(search) + "&tag_mode=all&api_key=5dfc80756edad8d0566cf40f0909324e&jsoncallback=?";
 
   $.getJSON(flickr_url, function(data) {
     if (data.stat == "ok") {
       var i = Math.ceil(Math.random() * data.photos.photo.length);
       var photo = data.photos.photo[i];
+      var attrib = "";
+      if(licdata = license_list[photo.license]) {
+        if(licdata.url) {
+          attrib = " (<a href=\"" + licdata.url + "\">" + licdata.shortname + "</a>)";
+        } else {
+          attrib = " (" + licdata.shortname + ")";
+        }
+      }
       next_kitten.img_url = "http://farm" + photo.farm + ".static.flickr.com/" + photo.server + "/" + photo.id + "_" + photo.secret + "_z.jpg";
       next_kitten.page_url = "http://www.flickr.com/photos/" + photo.owner + "/" + photo.id;
-      next_kitten.alt = photo.title + " by " + photo.ownername + " (under CC-BY)";
+      next_kitten.alt = photo.title + " by " + photo.ownername + attrib
       $("#nextKitten").attr("src", next_kitten.img_url);
     }
   });


### PR DESCRIPTION
A friend linked me to your site, and it's awesome, and of course I had to check out the Github.

I then noticed when testing the Easter egg that it was failing to pull in photos sporadically - to fix it, I tried escaping the query.  It didn't fix it, but I figured it'd be good to be safe anyway.  The real issue was that it assumed 100 photos were returned, which wasn't always true - even with the default search, I only got 95 kittens on one try.  So sometimes it would try pulling in a non-existent photo.  I used the count of the photos instead, so that it won't try to grab a photo that's not there.

I also got rid of the tmp variable since it wasn't really necessary here, but that's just my preference.
